### PR TITLE
Millora de seguretat i correció d'errors

### DIFF
--- a/src/AlumnesCicle.php
+++ b/src/AlumnesCicle.php
@@ -29,15 +29,15 @@ $CicleId = $_GET['CicleId'];
 
 CreaIniciHTML($Usuari, 'Alumnes cicle');
 
-$SQL = ' SELECT '.
-	' U.nom AS NomAlumne, U.cognom1 AS Cognom1Alumne, U.cognom2 AS Cognom2Alumne, M.curs_id, M.nivell, M.grup, M.alumne_id '.
-	' FROM MATRICULA M '.
-	' LEFT JOIN USUARI U ON (M.alumne_id=U.usuari_id) '.
-	' WHERE M.cicle_formatiu_id='.$CicleId.
-	' ORDER BY nivell, grup';
+$SQL = "SELECT U.nom AS NomAlumne, U.cognom1 AS Cognom1Alumne, U.cognom2 AS Cognom2Alumne, M.curs_id, M.nivell, M.grup, M.alumne_id 
+FROM MATRICULA M 
+LEFT JOIN USUARI U ON (M.alumne_id=U.usuari_id) 
+WHERE M.cicle_formatiu_id= ? ORDER BY nivell, grup";
 //print_r($SQL);
-
-$ResultSet = $conn->query($SQL);
+$stmt = $conn->prepare($SQL);
+$stmt->bind_param("i", $CicleId);
+$stmt->execute();
+$ResultSet = $stmt->get_result();
 
 if ($ResultSet->num_rows > 0) {
 	echo "<TABLE>";
@@ -51,7 +51,7 @@ if ($ResultSet->num_rows > 0) {
 		echo "<TD>".$row["nivell"]."</TD>";
 		echo "<TD>".$row["grup"]."</TD>";
 		echo "<TD>".utf8_encodeX($row["NomAlumne"]." ".$row["Cognom1Alumne"]." ".$row["Cognom2Alumne"])."</TD>";
-		echo utf8_encodeX("<TD><A HREF=MatriculaAlumne.php?AlumneId=".$row["alumne_id"].">Matrícula</A></TD>");
+		echo utf8_encodeX("<TD><A HREF=MatriculaAlumne.php?AlumneId=".$row["alumne_id"].">Matrï¿½cula</A></TD>");
 		echo utf8_encodeX("<TD><A HREF=MatriculaAlumne.php?accio=MostraExpedient&AlumneId=".$row["alumne_id"].">Expedient</A></TD>");
 		echo "</TR>";
 	}
@@ -61,19 +61,3 @@ if ($ResultSet->num_rows > 0) {
 $ResultSet->close();
 
 $conn->close();
-
-?>
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/CanviPassword.php
+++ b/src/CanviPassword.php
@@ -40,7 +40,7 @@ if (!empty($_POST))
 						$errors = [];
 						//print_r($_POST['contrase nya1']);
 						if (ComprovaFortalesaPassword($_POST['contrasenya1'], $errors)) {
-							$SQL = "UPDATE USARI SET password = ?, imposa_canvi_password = 0 WHERE usuari_id = ?;";
+							$SQL = "UPDATE USUARI SET password = ?, imposa_canvi_password = 0 WHERE usuari_id = ?;";
 							$stmt = $conn->prepare($SQL);
 							$stmt->bind_param("si", password_hash($_POST['contrasenya1'], PASSWORD_DEFAULT), $Usuari->usuari_id);
 							$stmt->execute();
@@ -115,7 +115,7 @@ if (!empty($_POST))
 		}
 		catch (Exception $e) 
 		{
-			$Text = "[File: ".getFile().", line ".$e->getLine()."]: ".$e->getMessage();
+			$Text = "[File: ".$e->getFile().", line ".$e->getLine()."]: ".$e->getMessage();
 			PaginaHTMLMissatge("Error", $Text);
 		}
 	}

--- a/src/CanviPassword.php
+++ b/src/CanviPassword.php
@@ -38,11 +38,14 @@ if (!empty($_POST))
 					// Canvi de la contrasenya a través de la contrasenya actual
 					if (($_POST['contrasenya1'] == $_POST['contrasenya2']) && ($_POST['contrasenya1'] != '')) {
 						$errors = [];
-	//print_r($_POST['contrase nya1']);
+						//print_r($_POST['contrase nya1']);
 						if (ComprovaFortalesaPassword($_POST['contrasenya1'], $errors)) {
-							$SQL = "UPDATE USUARI SET password='".password_hash($_POST['contrasenya1'], PASSWORD_DEFAULT)."', imposa_canvi_password=0 WHERE usuari_id=". $Usuari->usuari_id;
-	//print_r($SQL);
-							$conn->query($SQL);	
+							$SQL = "UPDATE USARI SET password = ?, imposa_canvi_password = 0 WHERE usuari_id = ?;";
+							$stmt = $conn->prepare($SQL);
+							$stmt->bind_param("si", password_hash($_POST['contrasenya1'], PASSWORD_DEFAULT), $Usuari->usuari_id);
+							$stmt->execute();
+							$stmt->close();
+							//print_r($SQL);
 							PaginaHTMLMissatge("Informació", "La contrasenya s'ha desat correctament.");
 							$log = new Registre($conn, $Usuari);
 							$log->Escriu(Registre::AUTH, 'Canvi de contrasenya');
@@ -61,13 +64,16 @@ if (!empty($_POST))
 			} 
 			else {
 				// Canvi de la contrasenya a través d'un email
-				$key = $_POST['clau'];
-				$email = $_POST['email'];
+				$key = mysqli_real_escape_string($conn, $_POST['clau']);
+				$email = mysqli_real_escape_string($conn, $_POST['email']);
 				
-				$SQL = "SELECT * FROM PASSWORD_RESET_TEMP WHERE clau='".$key."' and email='".$email."'";
+				$SQL = "SELECT * FROM PASSWORD_RESET_TEMP WHERE clau = ? and email = ?;";
+				$stmt = $conn->prepare($SQL);
+				$stmt->bind_param("ss", $key, $email);
+				$stmt->execute();
 //echo "SQL: $SQL<br>";
 
-				$ResultSet = $conn->query($SQL);
+				$ResultSet = $stmt->get_result();
 //print_r($ResultSet);
 				if ($ResultSet->num_rows < 1) {
 					PaginaHTMLMissatge("Enllaç invàlid", "L'enllaç és invàlid o ha caducat.");
@@ -82,10 +88,15 @@ if (!empty($_POST))
 							$errors = [];
 							if (ComprovaFortalesaPassword($_POST['contrasenya1'], $errors)) {
 								// Compte! Un email diferent per a cada usuari
-								$SQL = "UPDATE USUARI SET password='".password_hash($_POST['contrasenya1'], PASSWORD_DEFAULT)."' WHERE email='$email'";
-								$conn->query($SQL);	
-								$SQL = "DELETE FROM PASSWORD_RESET_TEMP WHERE email='$email'";
-								$conn->query($SQL);	
+								$SQL = "UPDATE USUARI SET password = ?, imposa_canvi_password = 0 WHERE email = ?;";
+								$stmt = $conn->prepare($SQL);
+								$stmt->bind_param("ss", password_hash($_POST['contrasenya1'], PASSWORD_DEFAULT), $email);
+								$stmt->execute();
+								
+								$SQL = "DELETE FROM PASSWORD_RESET_TEMP WHERE email = ?;";
+								$stmt = $conn->prepare($SQL);
+								$stmt->bind_param("s", $email);
+								$stmt->execute();
 								PaginaHTMLMissatge("Informació", "La contrasenya s'ha desat correctament.");
 							}
 							else {

--- a/src/Canvia.php
+++ b/src/Canvia.php
@@ -41,8 +41,7 @@ switch ($accio) {
 			header("Location: Surt.php");
 		$frm = new FormRecerca($conn, $Usuari, $Sistema);
 		$frm->Titol = "Usuaris";
-		$frm->SQL = 'SELECT usuari_id, username, nom, cognom1, cognom2, email, email_ins, codi, es_alumne, es_professor, es_pare, usuari_bloquejat '.
-			' FROM USUARI ORDER BY cognom1, cognom2, nom';
+		$frm->SQL = "SELECT usuari_id, username, nom, cognom1, cognom2, email, email_ins, codi, es_alumne, es_professor, es_pare, usuari_bloquejat FROM USUARI ORDER BY cognom1, cognom2, nom;";
 		$frm->Taula = 'USUARI';
 		$frm->ClauPrimaria = 'usuari_id';
 		$frm->Camps = 'nom, cognom1, cognom2, username, email, email_ins, codi, bool:es_alumne, bool:es_professor, bool:es_pare';
@@ -64,9 +63,12 @@ switch ($accio) {
 	case "CanviaAUsuari":
 		if (!$Usuari->es_admin)
 			header("Location: Surt.php");
-		$Id = $_GET['Id'];
-		$SQL = "SELECT * FROM USUARI WHERE usuari_id=$Id";
-		$ResultSet = $conn->query($SQL);
+		$Id = mysqli_real_escape_string($conn, $_GET['Id']);
+		$SQL = "SELECT * FROM USUARI WHERE usuari_id=?;";
+		$stmt = $conn->prepare($SQL);
+		$stmt->bind_param("i", $Id);
+		$stmt->execute();
+		$ResultSet = $stmt->get_result();
 		if ($ResultSet->num_rows > 0) {
 			$user = $ResultSet->fetch_object();
 			$user->era_admin = ($Usuari->es_admin == 1) ? 1 : 0;
@@ -86,5 +88,3 @@ switch ($accio) {
 		header("Location: Escriptori.php");
 		break;
 }
-
-?>

--- a/src/FPRecerca.php
+++ b/src/FPRecerca.php
@@ -89,10 +89,10 @@ switch ($accio) {
 		$frm = new FormRecerca($conn, $Usuari, $Sistema);
 		$frm->Modalitat = $Modalitat;
 		$frm->Titol = 'Mòduls professionals';
-		$frm->SQL = 'SELECT MP.modul_professional_id, MP.codi AS codi, MP.nom AS nom, hores, hores_setmana, MP.actiu, es_fct AS FCT, especialitat, cos, CF.codi AS CodiCF, CF.nom AS NomCF, FFP.nom AS NomFFP '.
-			' FROM MODUL_PROFESSIONAL MP '.
-			' LEFT JOIN CICLE_FORMATIU CF ON (CF.cicle_formatiu_id=MP.cicle_formatiu_id) '.
-			' LEFT JOIN FAMILIA_FP FFP ON (FFP.familia_fp_id=CF.familia_fp_id) ';
+		$frm->SQL = "SELECT MP.modul_professional_id, MP.codi AS codi, MP.nom AS nom, hores, hores_setmana, MP.actiu, es_fct AS FCT, especialitat, cos, CF.codi AS CodiCF, CF.nom AS NomCF, FFP.nom AS NomFFP
+		FROM MODUL_PROFESSIONAL MP
+		LEFT JOIN CICLE_FORMATIU CF ON (CF.cicle_formatiu_id=MP.cicle_formatiu_id)
+		LEFT JOIN FAMILIA_FP FFP ON (FFP.familia_fp_id=CF.familia_fp_id);";
 		$frm->Taula = 'MODUL_PROFESSIONAL';
 		$frm->ClauPrimaria = 'modul_professional_id';
 		$frm->Camps = 'codi, nom, hores, hores_setmana, bool:FCT, especialitat, cos, CodiCF, NomCF, NomFFP, bool:actiu';

--- a/src/Fitxa.php
+++ b/src/Fitxa.php
@@ -91,13 +91,12 @@ switch ($accio) {
 		$frm->AutoIncrement = True;
 		$frm->Id = $Id;
 		
-		$SQL = '
-			SELECT C.curs_id, C.nom 
+		$SQL = "SELECT C.curs_id, C.nom 
 			FROM CURS C
 			LEFT JOIN CICLE_PLA_ESTUDI CPE ON (CPE.cicle_pla_estudi_id=C.cicle_formatiu_id)
 			LEFT JOIN ANY_ACADEMIC AA ON (AA.any_academic_id=CPE.any_academic_id) 
-			WHERE actual=1
-			';
+			WHERE actual=1;
+			";
 		$aCurs = ObteCodiValorDesDeSQL($conn, $SQL, "curs_id", "nom");
 		$frm->AfegeixLlista('curs_id', 'Curs', 200, $aCurs[0], $aCurs[1]);
 		$frm->AfegeixLookUp('professor_id', 'Professor', 100, 'UsuariRecerca.php?accio=Professors', 'USUARI', 'usuari_id', 'nom, cognom1, cognom2');
@@ -145,8 +144,7 @@ switch ($accio) {
 		$frm->AutoIncrement = True;
 		$frm->Id = $Id;
 		
-		$SQL = 'SELECT AA.any_academic_id, AA.nom '.
-			' FROM ANY_ACADEMIC AA ORDER BY AA.nom DESC ';
+		$SQL = "SELECT AA.any_academic_id, AA.nom FROM ANY_ACADEMIC AA ORDER BY AA.nom DESC;";
 		$aCurs = ObteCodiValorDesDeSQL($conn, $SQL, "any_academic_id", "nom");
 		$frm->AfegeixLlista('any_academic_id', 'Any', 200, $aCurs[0], $aCurs[1]);
 		$frm->AfegeixLlista('tipus', 'Tipus', 30, array("DP", "ED", "CM"), array("Departament", "Equip docent", "Comissió"));
@@ -323,5 +321,3 @@ switch ($accio) {
 	case "Altre":
         break;
 }
-
-?>

--- a/src/FormMatricula.php
+++ b/src/FormMatricula.php
@@ -41,7 +41,7 @@ echo '</TR><TR>';
 //	' FROM CURS C'.
 //	' LEFT JOIN ANY_ACADEMIC AA ON (C.any_academic_id=AA.any_academic_id) '.
 //	' WHERE actual=1';
-$SQL = 'SELECT * FROM CURS_ACTUAL';
+$SQL = "SELECT * FROM CURS_ACTUAL;";
 $aCurs = ObteCodiValorDesDeSQL($conn, $SQL, "curs_id", "nom");
 echo $frmMatricula->CreaLlista('curs', 'Curs', 1000, $aCurs[0], $aCurs[1]);
 echo '</TR><TR>';

--- a/src/Grups.php
+++ b/src/Grups.php
@@ -47,12 +47,17 @@ CreaIniciHTML($Usuari, 'Grups', True);
 // https://community.esri.com/thread/187211-how-to-force-a-browser-cache-refresh-after-updating-wab-app
 echo '<script language="javascript" src="js/Matricula.js?v1.0" type="text/javascript"></script>';
 
-$SQL = ' SELECT * FROM MATRICULA M '.
-	' LEFT JOIN USUARI U ON (M.alumne_id=U.usuari_id) '.
-	' WHERE curs_id='.$CursId.
-	' ORDER BY U.cognom1, U.cognom2, U.nom ';
+$SQL = "SELECT * FROM MATRICULA M 
+				LEFT JOIN USUARI U ON (M.alumne_id=U.usuari_id) 
+				WHERE curs_id = ? 
+				ORDER BY U.cognom1, U.cognom2, U.nom;
+			";
 
-$ResultSet = $conn->query($SQL);
+$stmt = $conn->prepare($SQL);
+$stmt->bind_param("i", $CursId);
+$stmt->execute();
+
+$ResultSet = $stmt->get_result();
 
 $GrupClasse = new GrupClasse($conn, $Usuari);
 $aGrups = $GrupClasse->ObteGrups($CursId);

--- a/src/Matricula.php
+++ b/src/Matricula.php
@@ -35,10 +35,10 @@ RecuperaGET($_GET);
 
 CreaIniciHTML($Usuari, 'Matrícula');
 
-$alumne = $_POST['lkh_alumne'];
-$curs = $_POST['cmb_curs'];
-$grup = $_POST['cmb_grup'];
-$GrupTutoria = $_POST['cmb_grup_tutoria'];
+$alumne = mysqli_real_escape_string($conn, $_POST['lkh_alumne']);
+$curs = mysqli_real_escape_string($conn, $_POST['cmb_curs']);
+$grup = mysqli_real_escape_string($conn, $_POST['cmb_grup']);
+$GrupTutoria = mysqli_real_escape_string($conn, $_POST['cmb_grup_tutoria']);
 
 if (($alumne == '') || ($curs == '')) {
 	echo '<div class="alert alert-danger" id="MissatgeError" role="alert">';
@@ -68,9 +68,21 @@ else {
 		' WHERE C.curs_id='.$curs.
 		' AND C.nivell=UF.nivell '.
 		' ORDER BY MP.codi, UF.codi';
-//	print_r($SQL);
 
-	$ResultSet = $conn->query($SQL);
+	$SQL = "SELECT UF.nom AS NomUF, UF.hores AS HoresUF, MP.codi AS CodiMP, MP.nom AS NomMP, CF.nom AS NomCF, UF.*, MP.*, CF.*
+	FROM UNITAT_FORMATIVA UF
+	LEFT JOIN MODUL_PROFESSIONAL MP ON (MP.modul_professional_id=UF.modul_professional_id)
+	LEFT JOIN CICLE_FORMATIU CF ON (CF.cicle_formatiu_id=MP.cicle_formatiu_id)
+	LEFT JOIN CURS C ON (C.cicle_formatiu_id=CF.cicle_formatiu_id)
+	WHERE C.curs_id = ?
+	AND C.nivell=UF.nivell
+	ORDER BY MP.codi, UF.codi;";
+
+	$stmt = $conn->prepare($SQL);
+	$stmt->bind_param("i", $curs);
+	$stmt->execute();
+
+	$ResultSet = $stmt->get_result();
 	if ($ResultSet->num_rows > 0) {
 		echo '<TABLE class="table table-sm table-striped">';
 		echo '<THEAD class="thead-dark">';
@@ -93,5 +105,3 @@ else {
 }
 
 $conn->close();
-
-?>

--- a/src/MatriculaAlumne.php
+++ b/src/MatriculaAlumne.php
@@ -41,11 +41,11 @@ RecuperaGET($_GET);
 
 if (!empty($_POST)) {
 //	$alumne = $_POST['alumne'];
-	$MatriculaId = $_POST['MatriculaId'];
+	$MatriculaId = mysqli_real_escape_string($conn, $_POST['MatriculaId']);
 }
 else {
 //	$alumne = $_GET['AlumneId'];
-	$MatriculaId = $_GET['MatriculaId'];
+	$MatriculaId = mysqli_real_escape_string($conn, $_GET['MatriculaId']);
 }
 
 $Matricula = new Matricula($conn, $Usuari);

--- a/src/Notes.php
+++ b/src/Notes.php
@@ -32,7 +32,7 @@ RecuperaGET($_GET);
 
 $MetodeCongelaFilesComunes = (Config::UsaDataTables) ? Notes::tcDataTables : Notes::tcMetodeAntic;
 
-$CursId = $_GET['CursId'];
+$CursId = mysqli_real_escape_string($conn, $_GET['CursId']);
 $Curs = new Curs($conn, $Usuari);
 $Curs->CarregaRegistre($CursId);
 $CicleId = $Curs->ObteCicleFormatiuId();

--- a/src/Surt.php
+++ b/src/Surt.php
@@ -37,6 +37,7 @@ if ($conn->connect_error)
 $log = new Registre($conn, $Usuari);
 $log->Escriu(Registre::AUTH, 'Sortida del sistema');
 
+session_unset();
 session_destroy();
 header('Location: index.php');
 

--- a/src/lib/LibAvaluacio.ajax.php
+++ b/src/lib/LibAvaluacio.ajax.php
@@ -37,15 +37,16 @@ if (($_SERVER['REQUEST_METHOD'] === 'POST') && (isset($_REQUEST['accio']))) {
 		$Id = $_REQUEST['curs_id'];
 		$Estat = $_REQUEST['estat'];
 		// Canviem l'estat del curs
-		$SQL = 'UPDATE CURS SET estat="'.$Estat.'" WHERE curs_id='.$Id;
+		$SQL = "UPDATE CURS SET estat = ? WHERE curs_id = ?;";
+		$stmt = $conn->prepare($SQL);
+		$stmt->bind_param("si", $Estat, $Id);
+		$stmt->execute();
 		/* PENDENT !!!
 		if ($Estat == 'J') {
 			// Calculem les notes del mòduls que no estan calculades
 			$Avaluacio = new Avaluacio($conn, $Usuari);
 			$Avaluacio->CalculaNotesModul($Id);
 		}*/
-		$conn->query($SQL);
-		//print $SQL;
 	}
 	else if ($_REQUEST['accio'] == 'PosaEstatTrimestre') {
 		$Id = $_REQUEST['curs_id'];
@@ -54,7 +55,10 @@ if (($_SERVER['REQUEST_METHOD'] === 'POST') && (isset($_REQUEST['accio']))) {
 		$EsborraOrientatives = ($_REQUEST['esborra_orientatives'] == 1);
 		// Canviem l'estat del curs
 		$SQL = 'UPDATE CURS SET trimestre="'.$Trimestre.'" WHERE curs_id='.$Id;
-		$conn->query($SQL);
+		$SQL = "UPDATE CURS SET trimestre = ? WHERE curs_id = ?;";
+		$stmt = $conn->prepare($SQL);
+		$stmt->bind_param("si", $Trimestre, $Id);
+		$stmt->execute();
 		
 		if ($EsborraOrientatives) {
 			$Notes = new Notes($conn, $Usuari);

--- a/src/lib/LibAvaluacio.php
+++ b/src/lib/LibAvaluacio.php
@@ -364,32 +364,42 @@ class Avaluacio extends Objecte
 		// S'ha d'executar de forma atòmica
 		$this->Connexio->query('START TRANSACTION');
 		try {
-			$SQL = ' UPDATE CURS SET avaluacio="EXT", estat="A" WHERE curs_id='.$id;
-			if (!$this->Connexio->query($SQL))
-				throw new Exception($this->Connexio->error.'. SQL: '.$SQL);
+			$SQL = "UPDATE CURS SET avaluacio='EXT', estat='A' WHERE curs_id = ?;";
+			$Sentencia = $this->Connexio->prepare($SQL);
+			$Sentencia->bind_param('i', $id);
+			if (!$Sentencia->execute())
+				throw new Exception($Sentencia->error.'. SQL: '.$SQL);
 			
 			// MySQL no deixa fer un UPDATE amb una subconsulta. Es soluciona amb un wrapper.
 			// https://stackoverflow.com/questions/4429319/you-cant-specify-target-table-for-update-in-from-clause
-			$SQL = ' UPDATE NOTES SET convocatoria=0 WHERE notes_id IN ('.
-				'  SELECT notes_id FROM ('.
-				'     SELECT N.notes_id FROM NOTES N '.
-				'     LEFT JOIN MATRICULA M ON (M.matricula_id=N.matricula_id) '.
-				'     WHERE M.curs_id='.$id.' AND ObteNotaConvocatoria(nota1, nota2, nota3, nota4, nota5, convocatoria)>=5 '.
-				'  ) AS TEMP '.
-				')';
-			if (!$this->Connexio->query($SQL))
-				throw new Exception($this->Connexio->error.'. SQL: '.$SQL);
+			$SQL = "UPDATE NOTES SET convocatoria = 0 
+			WHERE notes_id IN (
+				SELECT notes_id FROM (
+					SELECT N.notes_id FROM NOTES N 
+					LEFT JOIN MATRICULA M ON (M.matricula_id=N.matricula_id) 
+					WHERE M.curs_id= ? 
+					AND ObteNotaConvocatoria(nota1, nota2, nota3, nota4, nota5, convocatoria)>=5) AS TEMP
+				)
+			);";
+			$Sentencia = $this->Connexio->prepare($SQL);
+			$Sentencia->bind_param('i', $id);
+			if (!$Sentencia->execute())
+				throw new Exception($Sentencia->error.'. SQL: '.$SQL);
 			
 			// Falta tractar les convocatòries de gràcia !!! (màxim 5)
-			$SQL = ' UPDATE NOTES SET convocatoria=convocatoria+1 WHERE notes_id IN ('.
-				'  SELECT notes_id FROM ('.
-				'     SELECT N.notes_id FROM NOTES N '.
-				'     LEFT JOIN MATRICULA M ON (M.matricula_id=N.matricula_id) '.
-				'     WHERE M.curs_id='.$id.' AND ObteNotaConvocatoria(nota1, nota2, nota3, nota4, nota5, convocatoria)<5 '.
-				'  ) AS TEMP '.
-				')';
-			if (!$this->Connexio->query($SQL))
-				throw new Exception($this->Connexio->error.'. SQL: '.$SQL);
+			$SQL = "UPDATE NOTES SET convocatoria=convocatoria+1 
+			WHERE notes_id IN (
+				SELECT notes_id FROM (
+					SELECT N.notes_id FROM NOTES N 
+					LEFT JOIN MATRICULA M ON (M.matricula_id=N.matricula_id) 
+					WHERE M.curs_id= ? 
+					AND ObteNotaConvocatoria(nota1, nota2, nota3, nota4, nota5, convocatoria)<5) AS TEMP
+				)
+			);";
+			$Sentencia = $this->Connexio->prepare($SQL);
+			$Sentencia->bind_param('i', $id);
+			if (!$Sentencia->execute())
+				throw new Exception($Sentencia->error.'. SQL: '.$SQL);
 			
 			$this->Connexio->query('COMMIT');
 		} 
@@ -411,12 +421,11 @@ class Avaluacio extends Objecte
 		// S'ha d'executar de forma atòmica
 		$this->Connexio->query('START TRANSACTION');
 		try {
-			$SQL = ' 
-				UPDATE CURS 
-				SET estat="T", data_tancament=now()
-				WHERE curs_id='.$id;
-			if (!$this->Connexio->query($SQL))
-				throw new Exception($this->Connexio->error.'. SQL: '.$SQL);
+			$SQL = "UPDATE CURS SET ESTAT='T', data_tancament=now() WHERE curs_id = ?;";
+			$Sentencia = $this->Connexio->prepare($SQL);
+			$Sentencia->bind_param('i', $id);
+			if (!$Sentencia->execute())
+				throw new Exception($Sentencia->error.'. SQL: '.$SQL);
 
 			// 2 i 3: Es fan al crear la següent matrícula (quan es copien les notes anteriors)
 
@@ -479,5 +488,3 @@ class Avaluacio extends Objecte
 		return $aRetorn;
 	}
 }
-
-?>

--- a/src/lib/LibExpedient.php
+++ b/src/lib/LibExpedient.php
@@ -1044,14 +1044,7 @@ class Acta extends Form
 	 * Nivell del curs (1 o 2).
 	 * @var int
 	 */
-	private $NivellCurs = -1;	
-
-	/**
-	 * Registre de les dades de la capçalera.
-	 * @var object
-	 */
-	private $Registre = null;	
-
+	private $NivellCurs = -1;
 	/**
 	 * Registre de les dades dels alumnes.
 	 * @var array

--- a/src/lib/LibForms.php
+++ b/src/lib/LibForms.php
@@ -481,7 +481,7 @@ class Form extends Objecte
 		$TextValor = '';
 		switch ($Calcul) {
 			case Form::tccEDAT:
-				$diff = date_diff(date_create("now"), date_create($Valor));
+				$diff = date_diff(date_create("now"), date_create($Valor ?? ''));
 				$TextValor = $diff->format("%y");
 //print("Edat: $TextValor<hr>");
 				break;

--- a/src/lib/LibForms.php
+++ b/src/lib/LibForms.php
@@ -58,7 +58,7 @@ class Objecte
 	* Registre per a emmagatzemar el resultat d'un DataSet.
 	* @var object
 	*/    
-    private $Registre = null;
+    public $Registre = null;
 	
 	/**
 	 * Constructor de l'objecte.
@@ -920,7 +920,7 @@ class FormRecerca extends Form
 
 	/**
 	* Llista de components (dates, combos) que permeten filtrar de forma específica.
-	* @var array
+	* @var object
 	*/    
     public $Filtre = []; 
 	
@@ -1035,8 +1035,8 @@ class FormRecerca extends Form
 				$sWhere .= '(';
 				foreach ($aCamps as $sCamp) {
 					$sCamp = $this->EliminaTipusPredefinit($sCamp);
-					if (array_key_exists($sCamp, $obj->CampAlies) && ($obj->CampAlies[$sCamp] != ''))
-						$sWhere .= $obj->CampAlies[$sCamp] . " LIKE '%" . $sValor . "%' OR ";
+					if (array_key_exists($sCamp, $obj->AliesCamp) && ($obj->AliesCamp[$sCamp] != ''))
+						$sWhere .= $obj->AliesCamp[$sCamp] . " LIKE '%" . $sValor . "%' OR ";
 					else
 						$sWhere .= $sCamp . " LIKE '%" . $sValor . "%' OR ";
 				}
@@ -3105,5 +3105,3 @@ class FormFitxaDetall extends FormFitxa
 		return $Retorn;
 	}
 }
-
-?>

--- a/src/lib/LibNotes.php
+++ b/src/lib/LibNotes.php
@@ -37,8 +37,8 @@ use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
  */
 function ObteTaulaNotesJSON($Connexio, $CicleId, $Nivell)
 {
-	$Notes = new Notes($conn, NULL);
-	$SQL = $Notes->CreaSQL($CursId, $Nivell);
+	$Notes = new Notes($Connexio, NULL);
+	$SQL = $Notes->CreaSQL($CicleId, $Nivell);
 
 	//return $SQL;
 	//print_r($SQL);
@@ -343,7 +343,7 @@ class Notes extends Form
 	 * Escriu el formulari corresponent a les notes d'un cicle i nivell (versió 1).
 	 * @param string $CicleId Identificador del cicle formatiu.
 	 * @param string $Nivell Nivell: 1r o 2n.
-	 * @param array $Notes Dades amb les notes.
+	 * @param object $Notes Dades amb les notes.
 	 * @param int $IdGraella Identificador de la graella de notes.
 	 * @param object $Professor Objecte professor.
 	 * @param object $Avaluacio Objecte avaluació.
@@ -469,7 +469,7 @@ class Notes extends Form
 	 * Escriu el formulari corresponent a les notes d'un cicle i nivell (versió DataTables).
 	 * @param string $CicleId Identificador del cicle formatiu.
 	 * @param string $Nivell Nivell: 1r o 2n.
-	 * @param array $Notes Dades amb les notes.
+	 * @param object $Notes Dades amb les notes.
 	 * @param int $IdGraella Identificador de la graella de notes.
 	 * @param object $Professor Objecte professor.
 	 * @param object $Avaluacio Objecte avaluació.
@@ -1374,7 +1374,7 @@ class Notes extends Form
 	
 	/**
 	 * Exporta les notes d'un registre (corresponent a 1r o 2n).
-	 * @param string $RegistreNotes Registre de notes.
+	 * @param object $RegistreNotes Registre de notes.
 	 * @param resource $handle Identificador del fitxer.
 	 * @param string $Nivell Nivell: 1r o 2n.
 	 * @param int $Tipus Tipus d'exportació: última nota, última convocatòria.
@@ -1551,7 +1551,7 @@ class Notes extends Form
 
 	/**
 	 * Exporta les notes d'un registre en format XLSX (corresponent a 1r o 2n).
-	 * @param string $RegistreNotes Registre de notes.
+	 * @param object $RegistreNotes Registre de notes.
 	 * @param string $Nivell Nivell: 1r o 2n.
 	 * @param int $Tipus Tipus d'exportació: última nota, última convocatòria.
 	 * @param string $filename Nom del fitxer.

--- a/src/lib/LibNotes.php
+++ b/src/lib/LibNotes.php
@@ -1875,13 +1875,7 @@ class Notes extends Form
  * Classe que encapsula les utilitats per al maneig de les notes del mòdul.
  */
 class NotesModul extends Notes 
-{
-	/**
-	* Registre carregat amb CarregaRegistre.
-	* @var object
-	*/    
-	private $Registre = NULL;
-	
+{	
 	/**
 	* Identificador del mòdul professional.
 	* @var integer

--- a/src/lib/LibPlaEstudis.php
+++ b/src/lib/LibPlaEstudis.php
@@ -25,7 +25,7 @@ abstract class PlaEstudis extends Form
 	* Registre carregat amb Carrega.
 	* @var object
 	*/    
-	protected $Registre = NULL;
+	/* protected $Registre = NULL; */
 	
 	/**
 	 * Genera el contingut HTML del formulari i el presenta a la sortida.

--- a/src/lib/LibSQL.php
+++ b/src/lib/LibSQL.php
@@ -145,7 +145,7 @@ print('<hr>');*/
      * @return void.
 	 */
 	private function CreaCampAlies() {
-		$this->CampAlies = array();
+		$this->AliesCamp = array();
 //print('<hr>');
 //print($this->Select);
 //print('<hr>');
@@ -180,7 +180,7 @@ print('<hr>');*/
 		foreach ($aCamps as $data) {
 			$i = strpos(strtoupper($data), ' AS ');
 			if ($i != 0)
-				$this->CampAlies[trim(substr($data, $i+4))] = trim(substr($data, 0, $i));
+				$this->AliesCamp[trim(substr($data, $i+4))] = trim(substr($data, 0, $i));
 		}
 	}
 
@@ -192,12 +192,10 @@ print('<hr>');*/
 	 */
 	public function ObteCampDesDeAlies($alies): string {
 		$Retorn = $alies;
-		foreach ($this->CampAlies as $key => $value) {
+		foreach ($this->AliesCamp as $key => $value) {
 			if ($key == $alies)
 				$Retorn = $value;
 		}
 		return $Retorn;
 	}
 }
-
-?>

--- a/src/lib/LibStr.php
+++ b/src/lib/LibStr.php
@@ -72,9 +72,9 @@ function Ordinal($Numero)
  * @param string $SQL Sentència SQL.
  * @param array $CampCodi Nom del camp del codi.
  * @param array $CampValor Nom del camp del valor.
- * @return void Array que conté 2 arrays (parell codi-valor).
+ * @return array Array que conté 2 arrays (parell codi-valor).
  */
-function Ocurrencies($array)
+function Ocurrencies($array): array
 {
 	$aRetorn = array();
 	$TextAnterior = '';

--- a/src/lib/LibURL.php
+++ b/src/lib/LibURL.php
@@ -48,7 +48,7 @@ function RecuperaGET(&$GET) {
 /**
  * Genera la URL en funció de si cal encriptar els paràmetres o no.
  * @param string $URL URL a generar.
- * @return URL generada.
+ * @return string URL generada.
  */
 function GeneraURL(string $URL): string {
 	return (Config::EncriptaURL) ? EncriptaURL($URL) : $URL;

--- a/src/lib/LibUsuari.php
+++ b/src/lib/LibUsuari.php
@@ -1474,7 +1474,7 @@ class ProfessorsEquip extends Objecte
 		$SQL = $this->CreaSQLProfessors($this->Id);
 		$ResultSet = $this->Connexio->query($SQL);
 		while($row = $ResultSet->fetch_object()) 
-			array_push($this->Professor, $row);
+			array_push($this->Professors, $row);
 	}
 
 	/**


### PR DESCRIPTION
- Canviades algunes de les sentències SQL per utilitzar prepared statements per prevenir futures injeccions
- Destruir la sessió de php a l'hora de tancar sessió
- Validar que les dades que agafem de $_GET i $_POST són strings vàlids sense possibles injeccions
- Afegit constructors a classes que entenen d'objecte per utilitzar les variables de la classe pare
- Arreglat noms de variables